### PR TITLE
fix: resolve npm publish issues

### DIFF
--- a/packages/cli/src/build.test.ts
+++ b/packages/cli/src/build.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("CLI build output", () => {
+  const distPath = join(import.meta.dir, "../dist/cli.js");
+
+  test("should have exactly one shebang line", () => {
+    const content = readFileSync(distPath, "utf-8");
+    const lines = content.split("\n");
+
+    // First line must be the shebang
+    expect(lines[0]).toBe("#!/usr/bin/env node");
+
+    // No other line should contain a shebang
+    const shebangs = lines.filter((l) => l.startsWith("#!"));
+    expect(shebangs).toHaveLength(1);
+  });
+
+  test("should be parseable by Node.js without syntax errors", async () => {
+    const proc = Bun.spawn(["node", "--check", distPath], {
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env bun
-
 import { DakClient } from "@littlelittlecloud/dak";
 import { searchCommand } from "./commands/search";
 import { feedsCommand } from "./commands/feeds";

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -27,10 +27,9 @@
     "build": "tsup",
     "prepublishOnly": "bun run build"
   },
-  "dependencies": {
-    "@dak/contract": "workspace:*"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "@dak/contract": "workspace:*",
     "tsup": "^8.4.0",
     "typescript": "^5.8.0"
   }

--- a/packages/sdk/src/build.test.ts
+++ b/packages/sdk/src/build.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("SDK package.json", () => {
+  const pkgPath = join(import.meta.dir, "../package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+
+  test("should not have workspace: protocol in dependencies", () => {
+    const deps = pkg.dependencies ?? {};
+    for (const [name, version] of Object.entries(deps)) {
+      expect(version).not.toMatch(
+        /^workspace:/,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Fixes #14

### Issue 1: `@littlelittlecloud/dak@0.3.1` — `workspace:*` in dependencies

`@dak/contract` was listed as a runtime `dependency` with `workspace:*`, which npm cannot resolve. Since tsup already bundles it via `noExternal`, moved it to `devDependencies`.

### Issue 2: `@littlelittlecloud/dak-cli` — duplicate shebang

Source file had `#!/usr/bin/env bun` on line 1, and `tsup.config.ts` injected `#!/usr/bin/env node` via `banner`. The resulting bundle had two shebang lines, causing a syntax error. Removed the source shebang.

### Tests added

- `packages/cli/src/build.test.ts` — verifies exactly one shebang and that `node --check` passes
- `packages/sdk/src/build.test.ts` — verifies no `workspace:` protocol in `dependencies`