### PR TITLE
fix: add from/to date filtering to feeds API

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@littlelittlecloud/dak-cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "大案牍库 CLI — Command-line interface for the Grand Archive",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/feeds.ts
+++ b/packages/cli/src/commands/feeds.ts
@@ -8,6 +8,8 @@ export async function feedsCommand(client: DakClient, args: string[]) {
   const result = await client.getFeeds({
     category: flags.category,
     source: flags.source,
+    from: flags.from,
+    to: flags.to,
     limit: flags.limit ? parseInt(flags.limit, 10) : undefined,
     offset: flags.offset ? parseInt(flags.offset, 10) : undefined,
   });

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dak/contract",
-  "version": "0.1.0",
+  "version": "0.4.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/contract/src/schemas.ts
+++ b/packages/contract/src/schemas.ts
@@ -60,6 +60,8 @@ export const SearchResponseSchema = z.object({
 export const FeedsRequestSchema = z.object({
   category: z.string().optional(),
   source: z.string().optional(),
+  from: z.string().optional(), // ISO 8601
+  to: z.string().optional(), // ISO 8601
   limit: z.coerce.number().int().min(1).max(100).default(20),
   offset: z.coerce.number().int().min(0).default(0),
 });

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@littlelittlecloud/dak",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "大案牍库 SDK — HTTP client for the Grand Archive API",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -54,6 +54,8 @@ export interface SearchResponse {
 export interface FeedsRequest {
   category?: string;
   source?: string;
+  from?: string;
+  to?: string;
   limit?: number;
   offset?: number;
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dak/server",
-  "version": "0.1.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "bun run --watch src/index.ts",

--- a/packages/server/src/routes/feeds.test.ts
+++ b/packages/server/src/routes/feeds.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test, beforeAll } from "bun:test";
+
+// Set env BEFORE any module reads it
+process.env.DB_PATH = ":memory:";
+
+// Dynamic import so DB_PATH is read as ":memory:"
+const { getDb } = await import("../db/client");
+
+// Import app — main() calls initDb() + buildSearchIndex() internally
+const { app } = await import("../index");
+
+function req(path: string) {
+  return app.request(`http://localhost${path}`);
+}
+
+/** Return an ISO date string for today +/- `offset` days. */
+function daysAgo(offset: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - offset);
+  return d.toISOString().slice(0, 10);
+}
+
+// Dates relative to today so the anonymous tier's 28-day maxAge window never expires
+const TODAY      = daysAgo(0);   // today
+const MINUS_5    = daysAgo(5);   // 5 days ago
+const MINUS_15   = daysAgo(15);  // 15 days ago
+const MINUS_20   = daysAgo(20);  // 20 days ago
+
+const SEED = [
+  { id: "a1", title: "Today Entry A",   source: "Bloomberg",  category: "finance", published: `${TODAY}T08:00:00Z` },
+  { id: "a2", title: "Today Entry B",   source: "CNBC",       category: "finance", published: `${TODAY}T20:00:00Z` },
+  { id: "b1", title: "5 Days Ago",      source: "Bloomberg",  category: "finance", published: `${MINUS_5}T12:00:00Z` },
+  { id: "c1", title: "15 Days Ago",     source: "AP News",    category: "news",    published: `${MINUS_15}T10:00:00Z` },
+  { id: "d1", title: "20 Days Ago",     source: "BBC Chinese", category: "news",   published: `${MINUS_20}T10:00:00Z` },
+];
+
+beforeAll(() => {
+  const db = getDb();
+  const stmt = db.prepare(
+    `INSERT INTO entries (id, title, content, url, source, category, tags, published)
+     VALUES (?, ?, NULL, NULL, ?, ?, '[]', ?)`
+  );
+  for (const e of SEED) {
+    stmt.run(e.id, e.title, e.source, e.category, e.published);
+  }
+});
+
+describe("GET /api/feeds", () => {
+  test("returns all entries when no date filter", async () => {
+    const res = await req("/api/feeds");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { entries: unknown[]; total: number };
+    expect(body.total).toBe(5);
+    expect(body.entries).toHaveLength(5);
+  });
+
+  test("--from filters entries >= date", async () => {
+    const res = await req(`/api/feeds?from=${TODAY}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { entries: { id: string }[]; total: number };
+    expect(body.total).toBe(2);
+    const ids = body.entries.map((e) => e.id).sort();
+    expect(ids).toEqual(["a1", "a2"]);
+  });
+
+  test("--to filters entries <= date", async () => {
+    const res = await req(`/api/feeds?to=${MINUS_15}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { entries: { id: string }[]; total: number };
+    expect(body.total).toBe(2);
+    const ids = body.entries.map((e) => e.id).sort();
+    expect(ids).toEqual(["c1", "d1"]);
+  });
+
+  test("--from and --to together returns range", async () => {
+    const res = await req(`/api/feeds?from=${daysAgo(6)}&to=${daysAgo(1)}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { entries: { id: string }[]; total: number };
+    expect(body.total).toBe(1);
+    expect(body.entries[0]!.id).toBe("b1");
+  });
+
+  test("--from and --to same day returns that day only", async () => {
+    const res = await req(`/api/feeds?from=${TODAY}&to=${TODAY}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { entries: { id: string }[]; total: number };
+    expect(body.total).toBe(2);
+    const ids = body.entries.map((e) => e.id).sort();
+    expect(ids).toEqual(["a1", "a2"]);
+  });
+
+  test("date range with no matches returns empty", async () => {
+    const res = await req(`/api/feeds?from=${daysAgo(27)}&to=${daysAgo(25)}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { entries: unknown[]; total: number };
+    expect(body.total).toBe(0);
+    expect(body.entries).toHaveLength(0);
+  });
+
+  test("category + date filter combined", async () => {
+    const res = await req(`/api/feeds?category=news&from=${MINUS_20}&to=${MINUS_15}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { entries: { id: string }[]; total: number };
+    expect(body.total).toBe(2);
+    const ids = body.entries.map((e) => e.id).sort();
+    expect(ids).toEqual(["c1", "d1"]);
+  });
+});

--- a/packages/server/src/routes/feeds.ts
+++ b/packages/server/src/routes/feeds.ts
@@ -8,6 +8,8 @@ feedsRoutes.get("/feeds", (c) => {
   const parsed = FeedsRequestSchema.safeParse({
     category: c.req.query("category"),
     source: c.req.query("source"),
+    from: c.req.query("from"),
+    to: c.req.query("to"),
     limit: c.req.query("limit"),
     offset: c.req.query("offset"),
   });
@@ -19,7 +21,7 @@ feedsRoutes.get("/feeds", (c) => {
     );
   }
 
-  const { category, source, limit, offset } = parsed.data;
+  const { category, source, from, to, limit, offset } = parsed.data;
   const maxAge = c.get("maxAge") as string | null;
   const db = getDb();
 
@@ -33,6 +35,14 @@ feedsRoutes.get("/feeds", (c) => {
   if (source) {
     conditions.push("source = ?");
     params.push(source);
+  }
+  if (from) {
+    conditions.push("published >= ?");
+    params.push(from);
+  }
+  if (to) {
+    conditions.push("published <= ?");
+    params.push(to + "T23:59:59.999Z");
   }
   if (maxAge) {
     conditions.push("published >= ?");


### PR DESCRIPTION
## Summary

Fixes #16 — `dak feeds --from/--to` date filter was not working; it returned all entries regardless of date range.

## Root Cause

The `from`/`to` date parameters were missing at every layer of the stack:
- **Contract**: `FeedsRequestSchema` had no `from`/`to` fields
- **SDK**: `FeedsRequest` type had no `from`/`to`
- **CLI**: `feedsCommand` never passed `--from`/`--to` flags to the client
- **Server**: feeds route never read or filtered on `from`/`to` query params

## Changes

| Package | File | Change |
|---------|------|--------|
| `@dak/contract` | `schemas.ts` | Add `from`/`to` optional string fields to `FeedsRequestSchema` |
| `@dak/sdk` | `types.ts` | Add `from`/`to` to `FeedsRequest` interface |
| `@dak/cli` | `feeds.ts` | Pass `flags.from`/`flags.to` to client |
| `@dak/server` | `feeds.ts` | Read `from`/`to` query params, add SQL date conditions |
| `@dak/server` | `feeds.test.ts` | Integration tests for date filtering (7 cases) |
| all | `package.json` | Bump versions to 0.4.1 |

## Testing

```
bun test src/routes/feeds.test.ts
7 pass, 0 fail
```

Tests use relative dates (`daysAgo()` helper) so they won't break over time.