### PR TITLE
feat(search): migrate to FTS5 + jieba tokenizer

### DIFF
--- a/packages/server/fly.toml
+++ b/packages/server/fly.toml
@@ -11,12 +11,12 @@ primary_region = "nrt"
 [http_service]
   internal_port = 3000
   force_https = true
-  auto_stop_machines = "off"
+  auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 0
 
 [[vm]]
-  memory = "1024mb"
+  memory = "512mb"
   cpu_kind = "shared"
   cpus = 1
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@dak/contract": "workspace:*",
+    "@node-rs/jieba": "^2.0.1",
     "hono": "^4.7.0",
     "minisearch": "^7.1.2"
   },

--- a/packages/server/src/search/bench.ts
+++ b/packages/server/src/search/bench.ts
@@ -1,0 +1,315 @@
+/**
+ * Benchmark: MiniSearch vs FTS5 search engine
+ *
+ * Run:  bun run src/search/bench.ts
+ *
+ * Uses an in-memory SQLite DB populated with synthetic entries,
+ * then compares init / add / search performance of both engines.
+ */
+
+process.env.DB_PATH = ":memory:";
+
+import { initDb, getDb } from "../db/client";
+import { MiniSearchEngine } from "./minisearch";
+import { Fts5SearchEngine } from "./fts5";
+import type { SearchEngine, IndexedEntry } from "./interface";
+
+// ── helpers ────────────────────────────────────────────────
+
+function randomFrom<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)]!;
+}
+
+const CATEGORIES = ["finance", "news", "tech", "social", "blog"] as const;
+const SOURCES = ["Bloomberg", "Reuters", "CNBC", "AP News", "BBC Chinese", "TechCrunch", "Hacker News"];
+
+const TITLE_PARTS_ZH = [
+  "中国人民银行", "发布", "新政策", "市场", "分析", "科技", "人工智能",
+  "经济", "增长", "数据", "报告", "美联储", "加息", "降息", "央行",
+  "股市", "房地产", "区块链", "芯片", "出口", "贸易", "制裁",
+  "通货膨胀", "就业", "消费", "投资", "能源", "石油", "黄金",
+];
+
+const TITLE_PARTS_EN = [
+  "Federal Reserve", "raises", "interest rates", "market analysis",
+  "tech stocks", "AI breakthrough", "quarterly earnings", "GDP growth",
+  "inflation data", "unemployment", "trade deal", "startup funding",
+  "IPO", "cryptocurrency", "regulation", "supply chain", "chip shortage",
+  "oil prices", "gold rally", "bond yields", "housing market",
+];
+
+const CONTENT_PARTS = [
+  "根据最新数据显示，全球经济正在经历显著的结构性变化。",
+  "分析师指出，当前市场走势受到多重因素影响。",
+  "According to the latest report, the economic outlook remains uncertain.",
+  "Experts predict significant changes in monetary policy direction.",
+  "投资者需要关注以下几个关键指标的变化趋势。",
+  "The central bank is expected to make a decision next week.",
+  "技术创新正在推动产业升级和经济转型。",
+  "Supply chain disruptions continue to impact global trade.",
+  "新的监管框架将对行业产生深远影响。",
+  "Market participants are closely watching developments in the region.",
+];
+
+function generateEntry(i: number): {
+  id: string;
+  title: string;
+  content: string;
+  source: string;
+  category: string;
+  published: string;
+} {
+  const titleParts = Math.random() > 0.4 ? TITLE_PARTS_ZH : TITLE_PARTS_EN;
+  const title = Array.from({ length: 3 + Math.floor(Math.random() * 3) }, () =>
+    randomFrom(titleParts)
+  ).join(" ");
+
+  const content = Array.from({ length: 2 + Math.floor(Math.random() * 3) }, () =>
+    randomFrom(CONTENT_PARTS)
+  ).join(" ");
+
+  const d = new Date();
+  d.setDate(d.getDate() - Math.floor(Math.random() * 365));
+
+  return {
+    id: `bench-${i}`,
+    title,
+    content,
+    source: randomFrom(SOURCES),
+    category: randomFrom(CATEGORIES),
+    published: d.toISOString().slice(0, 10) + "T12:00:00Z",
+  };
+}
+
+// ── seed DB ────────────────────────────────────────────────
+
+const ENTRY_COUNT = 10_000;
+const SEARCH_QUERIES = [
+  "人民银行",
+  "interest rates",
+  "加息",
+  "AI",
+  "市场分析",
+  "Federal Reserve",
+  "经济增长",
+  "chip shortage",
+  "黄金 石油",
+  "startup funding",
+];
+
+console.log(`\n📊 Search Engine Benchmark`);
+console.log(`   Entries: ${ENTRY_COUNT.toLocaleString()}`);
+console.log(`   Queries: ${SEARCH_QUERIES.length}\n`);
+
+initDb();
+const db = getDb();
+
+console.log("Seeding database...");
+const entries = Array.from({ length: ENTRY_COUNT }, (_, i) => generateEntry(i));
+
+const insertStmt = db.prepare(
+  `INSERT OR IGNORE INTO entries (id, title, content, url, source, category, tags, published)
+   VALUES (?, ?, ?, NULL, ?, ?, '[]', ?)`
+);
+const insertAll = db.transaction(
+  (items: typeof entries) => {
+    for (const e of items) {
+      insertStmt.run(e.id, e.title, e.content, e.source, e.category, e.published);
+    }
+  }
+);
+insertAll(entries);
+console.log(`Seeded ${ENTRY_COUNT.toLocaleString()} entries\n`);
+
+// ── benchmark runner ───────────────────────────────────────
+
+// ── memory helpers ─────────────────────────────────────────
+
+function formatMB(bytes: number): string {
+  return (bytes / 1024 / 1024).toFixed(2) + " MB";
+}
+
+function getMemoryUsage() {
+  if (typeof Bun !== "undefined") {
+    // Bun: use process.memoryUsage() which returns rss, heapTotal, heapUsed, external
+    return process.memoryUsage();
+  }
+  return process.memoryUsage();
+}
+
+// Force GC if available (bun --smol or node --expose-gc)
+function tryGC() {
+  if (typeof Bun !== "undefined" && typeof Bun.gc === "function") {
+    Bun.gc(true);
+  } else if (typeof globalThis.gc === "function") {
+    globalThis.gc();
+  }
+}
+
+interface BenchResult {
+  engine: string;
+  initMs: number;
+  addMs: number;
+  searchAvgMs: number;
+  memBeforeInit: { rss: number; heapUsed: number };
+  memAfterInit: { rss: number; heapUsed: number };
+  memAfterSearch: { rss: number; heapUsed: number };
+  searchResults: { query: string; total: number; topScore: number }[];
+}
+
+async function benchEngine(
+  name: string,
+  engine: SearchEngine
+): Promise<BenchResult> {
+  // Measure memory before init
+  tryGC();
+  const memBeforeInit = getMemoryUsage();
+
+  // init
+  const t0 = performance.now();
+  await engine.init();
+  const initMs = performance.now() - t0;
+
+  tryGC();
+  const memAfterInit = getMemoryUsage();
+
+  // add (simulate 100 new entries)
+  const newEntries: IndexedEntry[] = Array.from({ length: 100 }, (_, i) => {
+    const e = generateEntry(ENTRY_COUNT + i);
+    // Also insert into DB so FTS5 can find the rowid
+    db.prepare(
+      `INSERT OR IGNORE INTO entries (id, title, content, url, source, category, tags, published)
+       VALUES (?, ?, ?, NULL, ?, ?, '[]', ?)`
+    ).run(e.id, e.title, e.content, e.source, e.category, e.published);
+    return {
+      id: e.id,
+      title: e.title,
+      content: e.content,
+      source: e.source,
+      category: e.category,
+      published: e.published,
+    };
+  });
+
+  const t1 = performance.now();
+  engine.add(newEntries);
+  const addMs = performance.now() - t1;
+
+  // search
+  const searchResults: BenchResult["searchResults"] = [];
+  const ITERATIONS = 50; // run each query N times for stable avg
+
+  const t2 = performance.now();
+  for (let i = 0; i < ITERATIONS; i++) {
+    for (const q of SEARCH_QUERIES) {
+      const result = engine.search(q, { limit: 20 });
+      if (i === 0) {
+        searchResults.push({
+          query: q,
+          total: result.total,
+          topScore: result.results[0]?.score ?? 0,
+        });
+      }
+    }
+  }
+  const searchTotalMs = performance.now() - t2;
+  const searchAvgMs = searchTotalMs / (ITERATIONS * SEARCH_QUERIES.length);
+
+  tryGC();
+  const memAfterSearch = getMemoryUsage();
+
+  engine.dispose();
+
+  return {
+    engine: name,
+    initMs,
+    addMs,
+    searchAvgMs,
+    memBeforeInit: { rss: memBeforeInit.rss, heapUsed: memBeforeInit.heapUsed },
+    memAfterInit: { rss: memAfterInit.rss, heapUsed: memAfterInit.heapUsed },
+    memAfterSearch: { rss: memAfterSearch.rss, heapUsed: memAfterSearch.heapUsed },
+    searchResults,
+  };
+}
+
+// ── run benchmarks ─────────────────────────────────────────
+
+async function main() {
+  // Clean up any leftover FTS table from previous run
+  try { db.exec("DROP TABLE IF EXISTS entries_fts"); } catch {}
+
+  const results: BenchResult[] = [];
+
+  for (const [name, engine] of [
+    ["FTS5 + jieba", new Fts5SearchEngine()],
+    ["MiniSearch", new MiniSearchEngine()],
+  ] as [string, SearchEngine][]) {
+    console.log(`⏱  Benchmarking ${name}...`);
+    const r = await benchEngine(name, engine);
+    results.push(r);
+    console.log(
+      `   init: ${r.initMs.toFixed(1)}ms | add(100): ${r.addMs.toFixed(2)}ms | search avg: ${r.searchAvgMs.toFixed(3)}ms`
+    );
+    console.log(
+      `   mem: rss Δ${formatMB(r.memAfterInit.rss - r.memBeforeInit.rss)} | heap Δ${formatMB(r.memAfterInit.heapUsed - r.memBeforeInit.heapUsed)} (after init)`
+    );
+  }
+
+  // ── comparison table ─────────────────────────────────────
+  console.log("\n" + "═".repeat(72));
+  console.log("  Metric            │  FTS5 + jieba      │  MiniSearch");
+  console.log("─".repeat(72));
+
+  const fts5 = results[0]!;
+  const mini = results[1]!;
+  const row = (label: string, fv: string, mv: string) =>
+    console.log(`  ${label.padEnd(18)} │  ${fv.padEnd(18)} │  ${mv}`);
+
+  row("init()", `${fts5.initMs.toFixed(1)} ms`, `${mini.initMs.toFixed(1)} ms`);
+  row("add(100)", `${fts5.addMs.toFixed(2)} ms`, `${mini.addMs.toFixed(2)} ms`);
+  row("search (avg)", `${fts5.searchAvgMs.toFixed(3)} ms`, `${mini.searchAvgMs.toFixed(3)} ms`);
+
+  // Memory rows
+  const fts5RssDelta = fts5.memAfterInit.rss - fts5.memBeforeInit.rss;
+  const miniRssDelta = mini.memAfterInit.rss - mini.memBeforeInit.rss;
+  const fts5HeapDelta = fts5.memAfterInit.heapUsed - fts5.memBeforeInit.heapUsed;
+  const miniHeapDelta = mini.memAfterInit.heapUsed - mini.memBeforeInit.heapUsed;
+
+  row("RSS Δ (init)", formatMB(fts5RssDelta), formatMB(miniRssDelta));
+  row("Heap Δ (init)", formatMB(fts5HeapDelta), formatMB(miniHeapDelta));
+  row("RSS (total)", formatMB(fts5.memAfterSearch.rss), formatMB(mini.memAfterSearch.rss));
+  row("Heap (total)", formatMB(fts5.memAfterSearch.heapUsed), formatMB(mini.memAfterSearch.heapUsed));
+  row(
+    "init speedup",
+    fts5.initMs < mini.initMs
+      ? `${(mini.initMs / fts5.initMs).toFixed(1)}× faster`
+      : `${(fts5.initMs / mini.initMs).toFixed(1)}× slower`,
+    "baseline"
+  );
+  row(
+    "search speedup",
+    fts5.searchAvgMs < mini.searchAvgMs
+      ? `${(mini.searchAvgMs / fts5.searchAvgMs).toFixed(1)}× faster`
+      : `${(fts5.searchAvgMs / mini.searchAvgMs).toFixed(1)}× slower`,
+    "baseline"
+  );
+
+  console.log("═".repeat(72));
+
+  // ── per-query results ────────────────────────────────────
+  console.log("\n📋 Per-query results (total hits):");
+  console.log(
+    `  ${"Query".padEnd(20)} │  ${"FTS5".padEnd(8)} │  ${"MiniSearch".padEnd(8)}`
+  );
+  console.log("─".repeat(50));
+  for (let i = 0; i < SEARCH_QUERIES.length; i++) {
+    const fq = fts5.searchResults[i]!;
+    const mq = mini.searchResults[i]!;
+    console.log(
+      `  ${fq.query.padEnd(20)} │  ${String(fq.total).padEnd(8)} │  ${String(mq.total).padEnd(8)}`
+    );
+  }
+  console.log();
+}
+
+main().catch(console.error);

--- a/packages/server/src/search/engine.ts
+++ b/packages/server/src/search/engine.ts
@@ -1,108 +1,44 @@
-import MiniSearch from "minisearch";
-import { getDb } from "../db/client";
-import type { Entry, SearchResult } from "@dak/contract";
+export type { SearchEngine, IndexedEntry, SearchOptions, SearchOutput } from "./interface";
+import type { SearchEngine } from "./interface";
+import { Fts5SearchEngine } from "./fts5";
+import { MiniSearchEngine } from "./minisearch";
 
-interface IndexedEntry {
-  id: string;
-  title: string;
-  content: string;
-  source: string;
-  category: string;
-  published: string;
+let engine: SearchEngine;
+
+function createEngine(): SearchEngine {
+  const backend = process.env.SEARCH_ENGINE ?? "fts5";
+  switch (backend) {
+    case "minisearch":
+      return new MiniSearchEngine();
+    case "fts5":
+      return new Fts5SearchEngine();
+    default:
+      console.warn(`Unknown SEARCH_ENGINE="${backend}", falling back to fts5`);
+      return new Fts5SearchEngine();
+  }
 }
 
-let miniSearch: MiniSearch<IndexedEntry>;
+export function getSearchEngine(): SearchEngine {
+  if (!engine) {
+    engine = createEngine();
+  }
+  return engine;
+}
 
 export async function buildSearchIndex(): Promise<void> {
-  const db = getDb();
-  const rows = db
-    .query("SELECT id, title, source, category, published FROM entries")
-    .all() as IndexedEntry[];
-
-  miniSearch = new MiniSearch<IndexedEntry>({
-    fields: ["title"],
-    storeFields: ["title", "source", "category", "published"],
-    searchOptions: {
-      fuzzy: 0.2,
-      prefix: true,
-    },
-  });
-
-  miniSearch.addAll(rows);
-  console.log(`🔍 Search index built: ${rows.length} entries`);
+  const e = getSearchEngine();
+  await e.init();
 }
 
-export function addToIndex(entries: IndexedEntry[]): void {
-  if (!miniSearch) return;
-  for (const entry of entries) {
-    if (miniSearch.has(entry.id)) {
-      miniSearch.replace(entry);
-    } else {
-      miniSearch.add(entry);
-    }
-  }
+export function addToIndex(
+  entries: import("./interface").IndexedEntry[]
+): void {
+  getSearchEngine().add(entries);
 }
 
 export function search(
   query: string,
-  options?: {
-    category?: string;
-    source?: string;
-    from?: string;
-    to?: string;
-    maxAge?: string; // ISO date cutoff from tier middleware
-    limit?: number;
-    offset?: number;
-  }
-): { results: SearchResult[]; total: number; tierFiltered: boolean } {
-  if (!miniSearch) {
-    return { results: [], total: 0, tierFiltered: false };
-  }
-
-  let results = miniSearch.search(query);
-
-  // Apply filters
-  if (options?.category) {
-    results = results.filter((r) => r.category === options.category);
-  }
-  if (options?.source) {
-    results = results.filter((r) => r.source === options.source);
-  }
-
-  // Determine if tier cutoff is more restrictive than user-supplied `from`
-  let tierFiltered = false;
-  const fromDate = options?.maxAge ?? options?.from;
-  if (options?.maxAge) {
-    // Check if maxAge is actually clipping results the user asked for
-    const userFrom = options?.from;
-    if (!userFrom || options.maxAge > userFrom) {
-      tierFiltered = true;
-    }
-  }
-  if (fromDate) {
-    results = results.filter((r) => r.published >= fromDate);
-  }
-  if (options?.to) {
-    const to = options.to;
-    results = results.filter((r) => r.published <= to);
-  }
-
-  const total = results.length;
-
-  const limit = options?.limit ?? 20;
-  const offset = options?.offset ?? 0;
-  const paged = results.slice(offset, offset + limit);
-
-  return {
-    results: paged.map((r) => ({
-      id: r.id,
-      title: r.title as string,
-      source: r.source as string,
-      category: r.category as string,
-      published: r.published as string,
-      score: r.score,
-    })),
-    total,
-    tierFiltered,
-  };
+  options?: import("./interface").SearchOptions
+): import("./interface").SearchOutput {
+  return getSearchEngine().search(query, options);
 }

--- a/packages/server/src/search/fts5.ts
+++ b/packages/server/src/search/fts5.ts
@@ -1,0 +1,187 @@
+import { getDb } from "../db/client";
+import { tokenize } from "./tokenizer";
+import type {
+  SearchEngine,
+  IndexedEntry,
+  SearchOptions,
+  SearchOutput,
+} from "./interface";
+
+export class Fts5SearchEngine implements SearchEngine {
+  async init(): Promise<void> {
+    const db = getDb();
+
+    // Create FTS5 virtual table (content-less: we join back to entries for metadata)
+    db.exec(`
+      CREATE VIRTUAL TABLE IF NOT EXISTS entries_fts USING fts5(
+        title,
+        body,
+        content='',
+        content_rowid='rowid'
+      );
+    `);
+
+    // Rebuild index from entries table
+    const rows = db
+      .query("SELECT rowid, id, title, content FROM entries")
+      .all() as { rowid: number; id: string; title: string; content: string | null }[];
+
+    // Clear and repopulate
+    db.exec("DELETE FROM entries_fts");
+
+    const insert = db.prepare(
+      "INSERT INTO entries_fts(rowid, title, body) VALUES (?, ?, ?)"
+    );
+    const insertAll = db.transaction(
+      (items: { rowid: number; title: string; content: string | null }[]) => {
+        for (const item of items) {
+          insert.run(item.rowid, tokenize(item.title), tokenize(item.content ?? ""));
+        }
+      }
+    );
+
+    insertAll(rows);
+    console.log(`🔍 FTS5 index built: ${rows.length} entries`);
+  }
+
+  add(entries: IndexedEntry[]): void {
+    const db = getDb();
+
+    // Look up rowid for each entry and upsert into FTS
+    const getRowid = db.prepare(
+      "SELECT rowid FROM entries WHERE id = ?"
+    );
+    const deleteFts = db.prepare(
+      "INSERT INTO entries_fts(entries_fts, rowid, title, body) VALUES('delete', ?, ?, ?)"
+    );
+    const insertFts = db.prepare(
+      "INSERT INTO entries_fts(rowid, title, body) VALUES (?, ?, ?)"
+    );
+
+    const upsert = db.transaction((items: IndexedEntry[]) => {
+      for (const entry of items) {
+        const row = getRowid.get(entry.id) as { rowid: number } | null;
+        if (!row) continue;
+
+        const tokenizedTitle = tokenize(entry.title);
+        const tokenizedContent = tokenize(entry.content ?? "");
+
+        // Try delete old entry first (ignore if not there)
+        try {
+          deleteFts.run(row.rowid, tokenizedTitle, tokenizedContent);
+        } catch {
+          // Entry may not exist in FTS yet, that's fine
+        }
+        insertFts.run(row.rowid, tokenizedTitle, tokenizedContent);
+      }
+    });
+
+    upsert(entries);
+  }
+
+  search(query: string, options?: SearchOptions): SearchOutput {
+    const db = getDb();
+
+    const tokenizedQuery = tokenize(query);
+    if (!tokenizedQuery.trim()) {
+      return { results: [], total: 0, tierFiltered: false };
+    }
+
+    // Build WHERE clauses for filtering
+    const conditions: string[] = [];
+    const params: (string | number)[] = [];
+
+    if (options?.category) {
+      conditions.push("e.category = ?");
+      params.push(options.category);
+    }
+    if (options?.source) {
+      conditions.push("e.source = ?");
+      params.push(options.source);
+    }
+
+    // Determine effective date range
+    let tierFiltered = false;
+    const fromDate = options?.maxAge ?? options?.from;
+    if (options?.maxAge) {
+      const userFrom = options?.from;
+      if (!userFrom || options.maxAge > userFrom) {
+        tierFiltered = true;
+      }
+    }
+    if (fromDate) {
+      conditions.push("e.published >= ?");
+      params.push(fromDate);
+    }
+    if (options?.to) {
+      conditions.push("e.published <= ?");
+      params.push(options.to);
+    }
+
+    const whereClause =
+      conditions.length > 0 ? "AND " + conditions.join(" AND ") : "";
+
+    // FTS5 match query: quote each token to avoid syntax errors
+    const ftsQuery = tokenizedQuery
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((t) => `"${t.replace(/"/g, '""')}"`)
+      .join(" OR ");
+
+    // Count total
+    const countSql = `
+      SELECT COUNT(*) as total
+      FROM entries_fts f
+      JOIN entries e ON e.rowid = f.rowid
+      WHERE f.entries_fts MATCH ?
+      ${whereClause}
+    `;
+    const countRow = db.query(countSql).get(ftsQuery, ...params) as {
+      total: number;
+    };
+    const total = countRow.total;
+
+    // Fetch page
+    const limit = options?.limit ?? 20;
+    const offset = options?.offset ?? 0;
+
+    const selectSql = `
+      SELECT e.id, e.title, e.source, e.category, e.published,
+             rank * -1 as score
+      FROM entries_fts f
+      JOIN entries e ON e.rowid = f.rowid
+      WHERE f.entries_fts MATCH ?
+      ${whereClause}
+      ORDER BY rank
+      LIMIT ? OFFSET ?
+    `;
+
+    const rows = db
+      .query(selectSql)
+      .all(ftsQuery, ...params, limit, offset) as {
+      id: string;
+      title: string;
+      source: string;
+      category: string;
+      published: string;
+      score: number;
+    }[];
+
+    return {
+      results: rows.map((r) => ({
+        id: r.id,
+        title: r.title,
+        source: r.source,
+        category: r.category,
+        published: r.published,
+        score: r.score,
+      })),
+      total,
+      tierFiltered,
+    };
+  }
+
+  dispose(): void {
+    // FTS5 table lives in the DB, nothing to dispose
+  }
+}

--- a/packages/server/src/search/interface.ts
+++ b/packages/server/src/search/interface.ts
@@ -1,0 +1,40 @@
+import type { SearchResult } from "@dak/contract";
+
+export interface IndexedEntry {
+  id: string;
+  title: string;
+  content: string;
+  source: string;
+  category: string;
+  published: string;
+}
+
+export interface SearchOptions {
+  category?: string;
+  source?: string;
+  from?: string;
+  to?: string;
+  maxAge?: string; // ISO date cutoff from tier middleware
+  limit?: number;
+  offset?: number;
+}
+
+export interface SearchOutput {
+  results: SearchResult[];
+  total: number;
+  tierFiltered: boolean;
+}
+
+export interface SearchEngine {
+  /** Initialize / rebuild the full index from DB */
+  init(): Promise<void>;
+
+  /** Add or replace entries in the index */
+  add(entries: IndexedEntry[]): void;
+
+  /** Execute a search query with filters and pagination */
+  search(query: string, options?: SearchOptions): SearchOutput;
+
+  /** Dispose resources held by the engine */
+  dispose(): void;
+}

--- a/packages/server/src/search/minisearch.ts
+++ b/packages/server/src/search/minisearch.ts
@@ -1,0 +1,97 @@
+import MiniSearch from "minisearch";
+import { getDb } from "../db/client";
+import type { SearchResult } from "@dak/contract";
+import type {
+  SearchEngine,
+  IndexedEntry,
+  SearchOptions,
+  SearchOutput,
+} from "./interface";
+
+export class MiniSearchEngine implements SearchEngine {
+  private miniSearch: MiniSearch<IndexedEntry> | null = null;
+
+  async init(): Promise<void> {
+    const db = getDb();
+    const rows = db
+      .query("SELECT id, title, content, source, category, published FROM entries")
+      .all() as IndexedEntry[];
+
+    this.miniSearch = new MiniSearch<IndexedEntry>({
+      fields: ["title", "content"],
+      storeFields: ["title", "source", "category", "published"],
+      searchOptions: {
+        fuzzy: 0.2,
+        prefix: true,
+        boost: { title: 3 },
+      },
+    });
+
+    this.miniSearch.addAll(rows);
+    console.log(`🔍 MiniSearch index built: ${rows.length} entries`);
+  }
+
+  add(entries: IndexedEntry[]): void {
+    if (!this.miniSearch) return;
+    for (const entry of entries) {
+      if (this.miniSearch.has(entry.id)) {
+        this.miniSearch.replace(entry);
+      } else {
+        this.miniSearch.add(entry);
+      }
+    }
+  }
+
+  search(query: string, options?: SearchOptions): SearchOutput {
+    if (!this.miniSearch) {
+      return { results: [], total: 0, tierFiltered: false };
+    }
+
+    let results = this.miniSearch.search(query);
+
+    if (options?.category) {
+      results = results.filter((r) => r.category === options.category);
+    }
+    if (options?.source) {
+      results = results.filter((r) => r.source === options.source);
+    }
+
+    let tierFiltered = false;
+    const fromDate = options?.maxAge ?? options?.from;
+    if (options?.maxAge) {
+      const userFrom = options?.from;
+      if (!userFrom || options.maxAge > userFrom) {
+        tierFiltered = true;
+      }
+    }
+    if (fromDate) {
+      results = results.filter((r) => r.published >= fromDate);
+    }
+    if (options?.to) {
+      const to = options.to;
+      results = results.filter((r) => r.published <= to);
+    }
+
+    const total = results.length;
+    const limit = options?.limit ?? 20;
+    const offset = options?.offset ?? 0;
+    const paged = results.slice(offset, offset + limit);
+
+    return {
+      results: paged.map((r) => ({
+        id: r.id,
+        title: r.title as string,
+        source: r.source as string,
+        category: r.category as string,
+        published: r.published as string,
+        score: r.score,
+      })),
+      total,
+      tierFiltered,
+    };
+  }
+
+  dispose(): void {
+    this.miniSearch = null;
+  }
+}

--- a/packages/server/src/search/tokenizer.ts
+++ b/packages/server/src/search/tokenizer.ts
@@ -1,0 +1,16 @@
+import { Jieba } from "@node-rs/jieba";
+import { dict } from "@node-rs/jieba/dict";
+
+const jieba = Jieba.withDict(dict);
+
+/**
+ * Tokenize text using jieba cutForSearch (fine-grained, good for search recall).
+ * Filters out whitespace-only and single-punctuation tokens.
+ * Returns space-joined token string suitable for FTS5 indexing.
+ */
+export function tokenize(text: string): string {
+  const tokens = jieba.cutForSearch(text, true);
+  return tokens
+    .filter((t) => t.trim().length > 0 && !/^[\p{P}\p{S}]$/u.test(t))
+    .join(" ");
+}


### PR DESCRIPTION
## Summary

Migrate search engine from in-memory MiniSearch to SQLite FTS5 with jieba Chinese word segmentation.

### Changes

- **SearchEngine interface** (`interface.ts`): `init()`, `add()`, `search()`, `dispose()`
- **MiniSearchEngine** (`minisearch.ts`): refactored existing logic into class
- **Fts5SearchEngine** (`fts5.ts`): FTS5 virtual table + jieba tokenizer
- **Tokenizer** (`tokenizer.ts`): `@node-rs/jieba` with `cutForSearch` (fine-grained, HMM-enabled)
- **Factory** (`engine.ts`): switch via `SEARCH_ENGINE` env var (default: `fts5`)
- Both engines now index **title + content**
- Fly.io VM: 1024MB → 512MB + auto-stop enabled

### Benchmark (10K entries)

| Metric | FTS5 + jieba | MiniSearch |
|---|---|---|
| init() | 1,569 ms | 7,523 ms (**4.8× slower**) |
| add(100) | 2.13 ms | 12.02 ms |
| search (avg) | 3.59 ms | 11.37 ms (**3.2× slower**) |
| RSS Δ (init) | 175 MB | 1,144 MB (**6.5× more**) |
| Heap Δ (init) | 42 MB | 498 MB (**11.8× more**) |

Chinese recall is dramatically better with jieba (e.g. "人民银行": 1366 vs 2 hits).